### PR TITLE
New User Bug

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -35,7 +35,7 @@ class UserController < ApplicationController
     private
 
     def new_user_params
-        params.require(:email, :password).permit(:first_name, :last_name, :zip_code)
+        params.permit(:first_name, :last_name, :zip_code, :email, :password)
     end
 
     def login_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
     has_secure_password
-    validates_presence_of :first_name, :last_name, :email, :password, message: "First Name, Last Name, Email and Password are required fields"
+    validates_presence_of :first_name, :last_name, :email, :password
     validates_uniqueness_of :email
 end

--- a/app/views/user/new.html.erb
+++ b/app/views/user/new.html.erb
@@ -7,6 +7,10 @@
 <div class = "user_creation_form", show = false>
     Create an account by entering your information below:
     <%= form_with url: "/user/create", local: true do |f| %>
+        <%= f.label :"First Name" %>
+        <%= f.text_field :first_name, required: true %><br>
+        <%= f.label :"Last Name" %>
+        <%= f.text_field :last_name, required: true %><br>
         <%= f.label :"email" %>
         <%= f.text_field :email, required: true %><br>
         <%= f.label :"password" %>


### PR DESCRIPTION
## Context

while registering for an account, new users were experiencing a bug where the User would fail to save and redirect back to the new user form endlessly. The root of the issue was that the User model requires a first and last name, but the registration form did not include these fields.

## Work Performed

Added required `first_name` and `last_name` fields to the new user registration page. 