### PR TITLE
Asset Precompile HotFix

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,4 +2,3 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
-//= link form_toggle.js


### PR DESCRIPTION
### Context

The previous release deleted some unused Javascript files, but never removed them from the manifest.js, so the `rake assets:precompile` task was still trying to find them and erroring out when it couldn't. This removes the unused file name from the manifest.