### PR TITLE
Subnavigation Setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development, :test do
   # Testing
   gem 'rspec-rails'
   gem 'pry'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,13 @@ GEM
       ruby2_keywords
     error_highlight (0.6.0)
     erubi (1.12.0)
+    factory_bot (6.4.6)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
+    faker (3.3.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -280,6 +287,8 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.6)
   error_highlight (>= 0.4.0)
+  factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -36,7 +36,18 @@
     /* The navigation menu */
   .navbar {
     overflow: hidden;
-    background-color: #333;
+    background-color: inherit;
+    width: 60%;
+    min-width: 300px;
+    margin: 10px auto;
+  }
+
+  .acct-links {
+    float: right;
+
+    .subnav-btn {
+        float: right;
+    }
   }
   
   /* Navigation links */
@@ -54,7 +65,7 @@
   .subnav {
     float: left;
     overflow: hidden;
-    display: block;
+    display: inline;
   }
   
   /* Subnav button */
@@ -70,18 +81,32 @@
   }
   
   /* Add a red background color to navigation links on hover */
-  .navbar a:hover, .subnav:hover .subnav-btn:hover {
-    background-color: red;
+  .navbar a:hover, .subnav-btn:hover {
+    border-color: darkgoldenrod;
+    border: solid;
+    border-radius: 15px;
+    background-color: white;
+    color: darkgoldenrod;
+  }
+
+  .subnav:hover {
+    border: solid;
+    border-color: darkgoldenrod;
+    border-radius: 15px;
+    padding: 8px;
   }
   
   /* Style the subnav content - positioned absolute */
   .subnav-content {
     display: none;
-    position: absolute;
-    left: 0;
-    background-color: red;
-    width: 100%;
+    background-color: darkgoldenrod;
+    width: max-content;
     z-index: 1;
+
+    & ul {
+        list-style-type: none;
+        display: inherit;
+    }
   }
   
   /* Style the subnav links */
@@ -93,40 +118,23 @@
   
   /* Add a grey background color on hover */
   .subnav-content a:hover {
-    background-color: #eee;
-    color: black;
+    background-color: whitesmoke;
+    color: darkgoldenrod;
+    border-radius: 15px;
   }
   
   /* When you move the mouse over the subnav container, open the subnav content */
   .subnav:hover .subnav-content {
     display: block;
+    position: center;
+    background-color: darkgoldenrod;
+
+    & ul {
+        background-color: darkgoldenrod;
+    }
   }
 
 }
-    /* .primary-nav {
-        background-color: #060609;
-        list-style-type: none;
-        display: inline-block;
-         
-        & a {
-            text-align: center;
-            margin: 0;
-            display: inline-block;
-            inline-size: 16%;
-            min-inline-size: 100px;
-            background-color: #060609;
-            color: white;
-            text-decoration-line: none;
-        } 
-
-        & a:hover {
-            color: goldenrod;
-            size: 2em;
-            border: solid;
-            border-color: goldenrod;
-            border-radius: 10%;
-        }
-    } */
 
 .background-screen {
     height: 100vh;
@@ -266,6 +274,7 @@
     color: whitesmoke;
     text-align: justify;
     width: 60%;
+    min-width: 300px;
     margin: 10px auto;
     border-width: 4px;
     border-color: whitesmoke;
@@ -273,6 +282,7 @@
     border-radius: 30px;
     padding: 8px;
 }
+
 .display-recipe {
     .recipe-links {
         .link-list {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,9 +26,7 @@
     padding: 0;
     font-family: sans-serif;
  }
- li {
-    margin-left: 12px;
- }
+
  body {
     background-color: #060609;
  }
@@ -48,6 +46,7 @@
     .subnav-btn {
         float: right;
     }
+    
   }
   
   /* Navigation links */
@@ -272,7 +271,7 @@
 }
 .main-content {
     color: whitesmoke;
-    text-align: justify;
+    text-align: left;
     width: 60%;
     min-width: 300px;
     margin: 10px auto;
@@ -281,6 +280,14 @@
     border: solid;
     border-radius: 30px;
     padding: 8px;
+
+    & p {
+        padding: 8px;
+    }
+
+    ul {
+        margin-inline: 25px;
+     }
 }
 
 .display-recipe {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -34,7 +34,7 @@
  }
  nav {
     /* The navigation menu */
-.navbar {
+  .navbar {
     overflow: hidden;
     background-color: #333;
   }
@@ -70,7 +70,7 @@
   }
   
   /* Add a red background color to navigation links on hover */
-  .navbar a:hover, .subnav:hover .subnavbtn {
+  .navbar a:hover, .subnav:hover .subnav-btn:hover {
     background-color: red;
   }
   
@@ -127,7 +127,7 @@
             border-radius: 10%;
         }
     } */
-}
+
 .background-screen {
     height: 100vh;
     width: 100%;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,25 +33,92 @@
     background-color: #060609;
  }
  nav {
-    & ul {
+    /* The navigation menu */
+.navbar {
+    overflow: hidden;
+    background-color: #333;
+  }
+  
+  /* Navigation links */
+  .navbar a {
+    float: left;
+    font-size: 16px;
+    color: white;
+    text-align: center;
+    padding: 14px 16px;
+    text-decoration: none;
+    display: block;
+  }
+  
+  /* The subnavigation menu */
+  .subnav {
+    float: left;
+    overflow: hidden;
+    display: block;
+  }
+  
+  /* Subnav button */
+  .subnav .subnav-btn {
+    font-size: 16px;
+    border: none;
+    outline: none;
+    color: white;
+    padding: 14px 16px;
+    background-color: inherit;
+    font-family: inherit;
+    margin: 0;
+  }
+  
+  /* Add a red background color to navigation links on hover */
+  .navbar a:hover, .subnav:hover .subnavbtn {
+    background-color: red;
+  }
+  
+  /* Style the subnav content - positioned absolute */
+  .subnav-content {
+    display: none;
+    position: absolute;
+    left: 0;
+    background-color: red;
+    width: 100%;
+    z-index: 1;
+  }
+  
+  /* Style the subnav links */
+  .subnav-content a {
+    float: left;
+    color: white;
+    text-decoration: none;
+  }
+  
+  /* Add a grey background color on hover */
+  .subnav-content a:hover {
+    background-color: #eee;
+    color: black;
+  }
+  
+  /* When you move the mouse over the subnav container, open the subnav content */
+  .subnav:hover .subnav-content {
+    display: block;
+  }
+
+}
+    /* .primary-nav {
         background-color: #060609;
         list-style-type: none;
-        
-        & li {
+        display: inline-block;
+         
+        & a {
             text-align: center;
             margin: 0;
             display: inline-block;
             inline-size: 16%;
             min-inline-size: 100px;
             background-color: #060609;
-        } 
-
-        
-        & a {
             color: white;
             text-decoration-line: none;
-        }
-        
+        } 
+
         & a:hover {
             color: goldenrod;
             size: 2em;
@@ -59,7 +126,7 @@
             border-color: goldenrod;
             border-radius: 10%;
         }
-    }
+    } */
 }
 .background-screen {
     height: 100vh;

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,5 @@
 class DashboardController < ApplicationController
+    skip_before_action :require_login, only: [:index]
 
     def index
     end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,9 +1,15 @@
 class RecipesController < ApplicationController
 
+    skip_before_action :require_login, only: [:index, :show]
+
     def index
-        @authored_recipes = Recipe.where(author_id: current_user.id)
-        @user_recipes = current_user.recipes
-        @public_recipes = Recipe.where(private: false).where.not(id: @user_recipes.pluck(:recipe_id))
+        if logged_in?
+            @authored_recipes = Recipe.where(author_id: current_user.id)
+            @user_recipes = current_user.recipes
+            @public_recipes = Recipe.where(private: false).where.not(id: @user_recipes.pluck(:recipe_id))
+        else
+            @public_recipes = Recipe.where(private: false)
+        end
     end
 
     def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,8 @@ class User < ApplicationRecord
 
     has_many :user_recipes
     has_many :recipes, through: :user_recipes
+
+    def full_name
+        "#{first_name} #{last_name}"
+    end
 end

--- a/app/views/application/_nav_bar.html.erb
+++ b/app/views/application/_nav_bar.html.erb
@@ -1,21 +1,27 @@
-<nav class="nav-bar">
-    <span>
-    <ul class="nav-items">
-        <li>
-            <%= image_tag 'logo.png', class: "project-logo", alt: "The Recipe Social" %>
-        </li>
-        <li class="nav-bar-link" id="nbltd">
-            <a class="link-to-dashboard" href="/dashboard">HOME</a>
-        </li>
-        <li class="nav-bar-link" id="nbltr">
-            <a class="link-to-recipes" href="/recipes">RECIPES</a>
-        </li>
-        <li class="nav-bar-link" id=nbltf>
-            <a class="link-to-friends" href="/friends">FRIENDS</a>
-        </li>
-        <li class="nav-bar-link" id=nblo>
-            <a class="link-to-logout" href="/logout">LOG OUT</a>
-        </li>
-    </ul>
-    </span>
-</nav>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+<nav>
+    <%= image_tag 'logo.png', class: "project-logo", alt: "The Recipe Social" %>
+    <div class="navbar">
+    <a class="subnav-btn" href="/dashboard">HOME</a>
+    <div class='subnav'>
+        <%= button_to "RECIPES", {controller: "recipes", action: "index"}, {class: "subnav-btn", method: :get} %>
+        <div class=subnav-content>
+            <a href="/recipes/new">ADD A RECIPE</a>
+            <a href="#" title="Coming Soon!">SAVED RECIPES</a>
+            <a href="#" title="Coming Soon!">FIND NEW RECIPES</a>
+        </div>
+    </div>
+    <div class="subnav">
+        <button class="subnav-btn">ACCOUNT</button>
+        <div class="subnav-content">
+            <a href="#">UPDATE INFO</a>
+            <% if logged_in? %>
+                <a href="#">LOG OUT</a>
+            <% else %>
+                <a href="#">LOG IN / SIGN UP</a>
+            <% end %>
+        </div>
+    </div>
+    </div>
+</nav>  

--- a/app/views/application/_nav_bar.html.erb
+++ b/app/views/application/_nav_bar.html.erb
@@ -7,23 +7,27 @@
     <div class='subnav'>
         <%= button_to "RECIPES", {controller: "recipes", action: "index"}, {class: "subnav-btn", method: :get} %>
         <div class=subnav-content>
-            <a href="#" title="Coming Soon!">BROWSE RECIPES</a>
-            <% if logged_in? %>
-                <a href="/recipes/new">ADD A RECIPE</a>
-                <a href="#" title="Coming Soon!">SAVED RECIPES</a>
-            <% end %>
+            <ul>
+                <li><a href="#" title="Coming Soon!">BROWSE RECIPES</a></li>
+                <% if logged_in? %>
+                    <li><a href="/recipes/new">ADD A RECIPE</a></li>
+                    <li><a href="#" title="Coming Soon!">SAVED RECIPES</a></li>
+                <% end %>
+            </ul>
         </div>
     </div>
     <div class="acct-links">
         <div class="subnav">
             <button class="subnav-btn">ACCOUNT</button>
             <div class="subnav-content">
+            <ul>
                 <% if logged_in? %>
-                    <%= link_to('UPDATE ACCT', '#', title: 'Coming Soon!') if logged_in? %>
-                    <%= link_to('LOG OUT', '/logout', data: { turbo: false }) if logged_in? %>
+                    <li><%= link_to('UPDATE ACCT', '#', title: 'Coming Soon!') %></li>
+                    <li><%= link_to('LOG OUT', '/logout', data: { turbo: false }) %></li>
                 <% else %>
-                    <a href="/login">LOG IN / SIGN UP</a>
+                    <li><a href="/login">LOG IN / SIGN UP</a></li>
                 <% end %>
+            </ul>
             </div>
         </div>
     </div>

--- a/app/views/application/_nav_bar.html.erb
+++ b/app/views/application/_nav_bar.html.erb
@@ -7,21 +7,24 @@
     <div class='subnav'>
         <%= button_to "RECIPES", {controller: "recipes", action: "index"}, {class: "subnav-btn", method: :get} %>
         <div class=subnav-content>
-            <a href="/recipes/new">ADD A RECIPE</a>
-            <a href="#" title="Coming Soon!">SAVED RECIPES</a>
-            <a href="#" title="Coming Soon!">FIND NEW RECIPES</a>
-        </div>
-    </div>
-    <div class="subnav">
-        <button class="subnav-btn">ACCOUNT</button>
-        <div class="subnav-content">
-            <a href="#">UPDATE INFO</a>
+            <a href="#" title="Coming Soon!">BROWSE RECIPES</a>
             <% if logged_in? %>
-                <a href="#">LOG OUT</a>
-            <% else %>
-                <a href="#">LOG IN / SIGN UP</a>
+                <a href="/recipes/new">ADD A RECIPE</a>
+                <a href="#" title="Coming Soon!">SAVED RECIPES</a>
             <% end %>
         </div>
     </div>
+    <div class="acct-links">
+        <div class="subnav">
+            <button class="subnav-btn">ACCOUNT</button>
+            <div class="subnav-content">
+                <% if logged_in? %>
+                    <%= link_to('UPDATE ACCT', '#', title: 'Coming Soon!') if logged_in? %>
+                    <%= link_to('LOG OUT', '/logout', data: { turbo: false }) if logged_in? %>
+                <% else %>
+                    <a href="/login">LOG IN / SIGN UP</a>
+                <% end %>
+            </div>
+        </div>
     </div>
 </nav>  

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,6 +3,28 @@
     <p>Welcome, and thank you for visiting my demo project! Recipe-Social is a kitchen recordkeeping application that lets users create and share recipes and build their own libraries of other publically shared recipes. What's more, Recipe-Social also lets users track individual attempts at recipes, allowing them to track variables like deviation from the prescribed ingredients or instructions, embellishments or substitutions, as well as the effects on their outcomes. Assuming I can find a hosting service that I can afford, users may even be able to attach media like images and/or videos to these attempts and even to recipes themselves.</p>
     <br>
     <h1>Project Updates</h1>
+    <br>
+    <hr>
+    <br>
+    <h2>May 2, 2024</h2>
+    <br>
+    <h3>New Features and Dev Notes</h3>
+    <br>
+    <p>Hello Nav-bar! Now that this site has some resource-specific links, I wanted to set up a drop-down style subnavigation bar for recipe and account management links. This was accomplished entirely using HTML and CSS, no JavaScript on this one! While the new nav-bar features are likely the most obvious updates for existing users, returning users and visitors may note that the landing page has updated as well! This Blog page, as well as public recipes and individual recipe show pages are now accessable without logging in! Some features will be hidden (like adding new recipes) or otherwise disabled, but this should make for a more friendly reception for new users, giving them a chance to explore without necessarily signing up.</p>
+    <br>
+    <h3>Next Steps</h3>
+    <br>
+    <p>Next steps of this project are to continue building out the base functionality. There are several clumsy styling choices being made at current, and indeed the CSS file is slowly growing into a small nightmare, but for now the focus is on building basic CRUD functionality. While I'm thrilled to have the recipe portion of this project in relatively complete working order, there are a few more details to work out:</p>
+    <ul>
+        <li>There's currently no way to either delete a recipe (even for the author)</li>
+        <li>Nor to remove a recipe from your library</li>
+        <li>The Share link is also still nonfunctional, and I'm not entirely clear how I want that process to work yet, whether to share a recipe by searching an email, having a list of friends, or both</li>
+    </ul>
+    <br>
+    <p>There's also another major model to put together, but recipe attempts are going to be a little more like social media posts. Adding actual picture attachments will perhpas require a more complicated search for free or low-cost image hosting services, but the framework for the input should be reusable when the time comes to build forms for rendering Recipe Attempt show and edit views. Hopefully I can get some basic level of this working soon for a new release, as well as the issues above</p>
+    <br><hr><br>
+
+
     <h2>April 23, 2024 - The Recipe Library</h2>
     <br>
     <h3>Features and Dev Notes</h3>
@@ -15,11 +37,5 @@
     <br>
     <h3>Next Steps</h3>
     <br>
-    <p>Next steps of this project are to continue building out the base functionality. There are several clumsy styling choices being made at current, and indeed the CSS file is slowly growing into a small nightmare, but for now the focus is on building basic CRUD functionality. While I'm thrilled to have the recipe portion of this project in relatively complete working order, there are a few more details to work out:<p>
-    <ul>
-        <li>There's currently no way to either delete a recipe (even for the author)</li>
-        <li>Nor to remove a recipe from your library</li>
-        <li>The Share link is also still nonfunctional, and I'm not entirely clear how I want that process to work yet, whether to share a recipe by searching an email, having a list of friends, or both</li>
-    </ul>
-    <br>
-    <p>There's also another major model to put together, but recipe attempts are going to be a little more like social media posts. Adding actual picture attachments will perhpas require a more complicated search for free or low-cost image hosting services, but the framework for the input should be reusable when the time comes to build forms for rendering Recipe Attempt show and edit views. Hopefully I can get some basic level of this working soon for a new release, as well as the issues above</p>
+    <p> Updates in the coming weeks could be a bit slower! I am starting to work through some proper front-end curiculum, and so I might try to complement that with some light work updating the nav-bar. Ideally, now that this application has some resource-based links people could want to visit, I'd like to set this up as a dropdown subnavigation, which I think I could even do with pure CSS and no JavaScript. Stay tuned!</p>
+    

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   </head>
 
   <body>
-    <%= render(partial: "nav_bar") if logged_in? %>
+    <%= render(partial: "nav_bar") %>
     <%= render(partial: "system_messages", locals: { error: flash[:error], message: flash[:message] }) if flash[:error] || flash[:message] %>
     <%= yield %> 
   </body>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -9,24 +9,25 @@
     <%= link_to "CREATE A RECIPE", "/recipes/new" %><br>
     <br>
 
-    <h3>Your Authored Recipes</h3>
-    
-    <% if @authored_recipes.empty? %>
-        <p>You haven't added any recipes</p>
-    <% else %>
-        <% @authored_recipes.each do |recipe| %>
-            <h4><%= link_to "#{recipe.link_name}", "/recipes/#{recipe.id}" %></h4>
-        <% end %>
-    <% end %>
-
-    <h3>Your Saved Recipes</h3>
-    <% @user_recipes.each do |recipe| %>
-        <h4><%= link_to "#{recipe.link_name}", "/recipes/#{recipe.id}" %></h4>
-    <%end%>
-
     <h3>Browse Public Recipes</h3>
     <% @public_recipes.each do |recipe| %>
         <h4><%= link_to "#{recipe.link_name}", "/recipes/#{recipe.id}" %></h4>
-    <%end%>
+    <% end %>
 
+    <% if logged_in? %>
+        <h3>Your Authored Recipes</h3>
+        <% if @authored_recipes.empty? %>
+            <p>You haven't added any recipes</p>
+        <% else %>
+            <% @authored_recipes.each do |recipe| %>
+                <h4><%= link_to "#{recipe.link_name}", "/recipes/#{recipe.id}" %></h4>
+            <% end %>
+        <% end %>
+
+        <h3>Your Saved Recipes</h3>
+        <% @user_recipes.each do |recipe| %>
+            <h4><%= link_to "#{recipe.link_name}", "/recipes/#{recipe.id}" %></h4>
+        <% end %>
+    <% end %>
+    
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
-  root "session#index"
+  root "dashboard#index"
 
   get "/logout" => "session#destroy"
+  get "/login" => "session#index"
 
   get "/dashboard" => "dashboard#index"
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    zip_code { Faker::Address.zip_code }
+    email { Faker::Internet.email }
+    password { "STRONG PASSWORD" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,4 +16,17 @@ RSpec.describe 'User' do
             expect(new_user.id).not_to be nil
         end
     end
+
+    describe 'Unit Tests' do
+        describe '#full_name' do
+
+            let(:new_user) {FactoryBot.create(:user)}
+
+            it "pulls the first_name and last_name from a user's record, concatinates and retusn them" do
+                expected = "#{new_user.first_name} #{new_user.last_name}"
+
+                expect(new_user.full_name).to match expected
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Initial Sub-Navigation Setup

### Context

The previous release gave us a few recipe-specific pages, but no great way to access them. Links had been temporarily hardcoded into the Recipe Index page at `/recipes`, but there were no other easy ways to access the new recipe page, for example. 

What we need is some sort of sub-navigation feature, which will allow us to have more links in the navigation bar that are better organized and more easily navigable. 

### Work Performed

This PR is a near total redesign of the navbar partial and its styling. All of the sub navigation links are now hardcoded into the partial, with a few strategically placed layout elements organizing sub-navigation elements underneath a header button. Using CSS only, hovering on a header button will display a drop-down menu containing sub-navigation elements.

This also restructures some of the authentication checks and permissions, allowing users who are not logged in to access the blog/dashboard as well as to browse and view public recipes.  