### PR TITLE
Fix visitor recipe show

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -285,7 +285,7 @@
         padding: 8px;
     }
 
-    ul {
+    ul, ol {
         margin-inline: 25px;
      }
 }

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -34,7 +34,7 @@ class RecipesController < ApplicationController
 
     def show
         @recipe = Recipe.includes(:recipe_steps, :recipe_ingredients, :user_recipes).find_by(id: params[:id])
-        @user_recipe = @recipe&.user_recipes&.find_by(user_id: current_user.id)
+        @user_recipe = @recipe&.user_recipes&.find_by(user_id: current_user&.id)
         if @recipe.nil? || (@recipe.private? && @user_recipe.nil?)
             flash[:error] = "Sorry, we can't seem to find that recipe right now."
             redirect_to "/recipes"

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,28 +1,31 @@
 <div class='main-content'>
     <div class='display-recipe'>
         <h1><%= @recipe.name %></h1>
-        <br>
-        <div class='recipe-links'>
-            <ul class='link-list'>
+        <hr>
+        <% if logged_in? %>
+            <br>
+            <div class='recipe-links'>
+                <ul class='link-list'>
+                
+                    <% if  @recipe.author_id == current_user.id %>
+                        <li><%= link_to "EDIT THIS RECIPE", "/recipes/#{@recipe.id}/edit" %></a></li>
+                    <% end %>
 
-                <% if @recipe.author_id == current_user.id %>
-                    <li><%= link_to "EDIT THIS RECIPE", "/recipes/#{@recipe.id}/edit" %></a></li>
-                <% end %>
+                    <li><%= link_to "SHARE THIS RECIPE", "#", title: "Coming Soon!", class: 'preview-link' %></li>
 
-                <li><%= link_to "SHARE THIS RECIPE", "#", title: "Coming Soon!", class: 'preview-link' %></li>
+                    <% if @user_recipe.nil? %>
+                        <li><%= link_to "ADD TO LIBRARY", "/recipes/#{@recipe.id}/users/create", method: 'post', data: {turbo_method: :post} %></li>
+                    <% else %>
+                        <li><%= link_to "REMOVE FROM LIBRARY", "/recipes/#{@recipe.id}/users/#{current_user.id}/delete", method: 'delete', data: {turbo_method: :delete} %></li>
+                    <% end %>
 
-                <% if @user_recipe.nil? %>
-                    <li><%= link_to "ADD TO LIBRARY", "/recipes/#{@recipe.id}/users/create", method: 'post', data: {turbo_method: :post} %></li>
-                <% else %>
-                    <li><%= link_to "REMOVE FROM LIBRARY", "/recipes/#{@recipe.id}/users/#{current_user.id}/delete", method: 'delete', data: {turbo_method: :delete} %></li>
-                <% end %>
-
-            </ul>
-        </div>
+                </ul>
+            </div>
+        <% end %>
         <br>
         <p><%= @recipe.description %></p>
         <br>
-
+        <hr>
         <h2>Ingredients</h2>
         <br>
         <ul>


### PR DESCRIPTION
## Context

Last release was pushed live with a bug. Users who are not logged in were now permitted to visit a public recipe's show page, but the controller and view still had some references to user recipes and user ids.

## Work Performed

This fix is just to put some logic around those variables to prevent their use if a user is not logged in, and makes a quick style fix to ordered lists so that they are now in-line vertically with unordered lists.